### PR TITLE
Update predict_imagenet_label.py

### DIFF
--- a/predict_imagenet_label.py
+++ b/predict_imagenet_label.py
@@ -10,7 +10,8 @@ import os
 import time
 import torch
 from timm.data import ImageDataset, create_loader, resolve_data_config
-from timm.models import apply_test_time_pool, create_model
+from timm.models import create_model
+from timm.models.layers import apply_test_time_pool
 from timm.utils import AverageMeter, setup_default_logging
 
 torch.backends.cudnn.benchmark = True


### PR DESCRIPTION
To adapt latest version of `timm`
Replace [line 13](https://github.com/ToTheBeginning/GCP-Colorization/blob/1c0126c09d02e6766987d05f9fbf65c4798e7cd5/predict_imagenet_label.py#L13) in `predict_imagenet_label.py` with code shows below

```
from timm.models import create_model
from timm.models.layers import apply_test_time_pool
```

Test with `timm` version `0.9.0`